### PR TITLE
Fix service provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build
 composer.lock
 vendor
+.idea

--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,9 @@
 {
-    "name": "francescomalatesta/laravel-feature",
+    "name": "TotalServerSolutions/laravel-feature",
     "type": "library",
     "description": "A simple package to manage feature flagging in a Laravel project.",
     "keywords": ["laravel", "feature", "flag"],
-    "homepage": "https://github.com/francescomalatesta/laravel-feature",
+    "homepage": "https://github.com/totalserversolutions/laravel-feature",
     "license": "MIT",
     "authors": [
         {
@@ -11,6 +11,12 @@
             "email": "hellofrancesco@gmail.com",
             "homepage": "https://github.com/francescomalatesta",
             "role": "Developer"
+        },
+        {
+          "name": "Total Server Solutions",
+          "email": "dev@toatlserversolutions.com",
+          "homepage": "https://toatlserversolutions.com",
+          "role": "Developer"
         }
     ],
     "require": {

--- a/src/Provider/FeatureServiceProvider.php
+++ b/src/Provider/FeatureServiceProvider.php
@@ -21,6 +21,9 @@ class FeatureServiceProvider extends ServiceProvider
         $this->publishes([
             __DIR__.'/../Config/features.php' => config_path('features.php'),
         ]);
+
+        $this->registerBladeDirectives();
+        $this->registerConsoleCommand();
     }
 
     /**
@@ -37,9 +40,6 @@ class FeatureServiceProvider extends ServiceProvider
         $this->app->bind(FeatureRepositoryInterface::class, function () use ($config) {
             return app()->make($config->get('features.repository'));
         });
-
-        $this->registerBladeDirectives();
-        $this->registerConsoleCommand();
     }
 
     private function registerBladeDirectives()


### PR DESCRIPTION
## Description
Fix for https://github.com/laravel/framework/pull/25497
by moving registration of blade directives and console commands to `boot` method of service provider.
## Motivation and context
Changes in Laravel 5.8 threw errors when blade directives were registered in the `register` method of the service provider, preventing an upgrade
## How has this been tested?
I copied the modified source into my TCP local, and loaded the site. Menu options behind `@featurefor` were shown.
## Next steps
remove old lib and replace with this in TCP